### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-web-contest-sandbox.yml
+++ b/.github/workflows/publish-web-contest-sandbox.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         echo "tag=, latest" >> $GITHUB_OUTPUT
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@main
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         ROBOTOLOGY_SUPERBUILD_RELEASE: ${{ inputs.superbuild_release }}
         BUILD_TYPE: ${{ inputs.build_type }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore